### PR TITLE
Add threshold check on pill's position

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -52,7 +52,17 @@ class ReactSwitch extends Component {
       this.$checkedPos,
       Math.max(this.$uncheckedPos, newPos)
     );
-    this.setState({ $pos, $isDragging: true });
+    this.setState({ $pos: $pos });
+
+    if (checked) {
+      if ((startPos - $pos) > 10) {
+        this.setState({ $isDragging: true });
+      }
+    } else {
+      if (newPos > 10) {
+        this.setState({ $isDragging: true });
+      }
+    }
   }
 
   $onDragStop(event) {


### PR DESCRIPTION
It will only set $isDragging to true after the pill's position reaches a minimum threshold. If it doesn't, then it's considered a normal click event.