### PR TITLE
Treat dragging as a click event if it's less than 250 ms

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -40,7 +40,11 @@ class ReactSwitch extends Component {
   }
 
   $onDragStart(clientX) {
-    this.setState({ $startX: clientX, $hasOutline: true });
+    this.setState({
+      $startX: clientX,
+      $hasOutline: true,
+      $dragStartingTime: Date.now()
+    });
   }
 
   $onDrag(clientX) {
@@ -56,12 +60,18 @@ class ReactSwitch extends Component {
   }
 
   $onDragStop(event) {
-    const { $pos, $isDragging } = this.state;
+    const { $pos, $isDragging, $dragStartingTime } = this.state;
     const { checked, onChange, id } = this.props;
 
     // Simulate clicking the handle
     if (!$isDragging) {
       this.setState({ $hasOutline: false });
+      onChange(!checked, event, id);
+      return;
+    }
+    const timeSinceStart = Date.now() - $dragStartingTime;
+    if (timeSinceStart < 250) {
+      this.setState({ $isDragging: false, $hasOutline: false });
       onChange(!checked, event, id);
       return;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
   },
   devServer: {
     contentBase: path.join(__dirname, "demo/dist"),
-    port: 8000
+    port: 8000,
+    host: "0.0.0.0"
   }
 };


### PR DESCRIPTION
This is meant to solve the problem where a user clicks the switch to change its checked state, but they drag the handle a little bit while they click. In this case the user might expect the switch to change state, but it doesn't since the user didn't drag it far enough.

This change makes it so that any drag will change the switch from checked to unchecked or vice versa as long as the total duration of the drag was less than 250 ms.

The new behaviour might come off to users as inconsistent, so I'm not sure yet if this is an improvement.