### PR TITLE
Replace deprecated lifecycle hook

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,9 +39,13 @@ class ReactSwitch extends Component {
     this.$getInputRef = this.$getInputRef.bind(this);
   }
 
-  componentWillReceiveProps({ checked }) {
-    const $pos = checked ? this.$checkedPos : this.$uncheckedPos;
-    this.setState({ $pos });
+  componentDidUpdate(prevProps) {
+    if (prevProps.checked === this.props.checked) {
+      return;
+    }
+
+    const $pos = this.props.checked ? this.$checkedPos : this.$uncheckedPos;
+    this.setState({ $pos });    
   }
 
   $onDragStart(clientX) {


### PR DESCRIPTION
Hello,

First of all, thank you for maintaining this awesome library, it's simple but very useful.

I have wrapped my in-development app in a strict mode and got the following warning:
```
Warning: Unsafe lifecycle methods were found within a strict-mode tree:
    in StrictMode (at _app.js:37)
    in Container (at _app.js:36)
    in MyApp

componentWillReceiveProps: Please update the following components to use static getDerivedStateFromProps instead: ReactSwitch

Learn more about this warning here:
https://fb.me/react-strict-mode-warnings
```

This pull request replaces the deprecated lifecycle method. All tests pass, however, we get a linter warning which we might want to disable, as per discussion here: https://github.com/airbnb/javascript/issues/1875

Looking forward to your thoughts, I would love to get this fixed to be able to use the strict mode and in the future all the React performance goodies.

Thanks