### PR TITLE
[Fix] typescript props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ type excludedHTMLInputProps =
 type allowedHTMLinputProps = Omit<htmlInputProps, excludedHTMLInputProps>;
 
 declare class ReactSwitch extends React.Component<
-  ReactSwitchProps | allowedHTMLinputProps
+  ReactSwitchProps & allowedHTMLinputProps
 > {}
 
 export default ReactSwitch;


### PR DESCRIPTION
I finally had time to switch to v5 of this library, however, my type checker threw some errors. After a short investigation I noticed I made a small mistake on the Typescript code I suggested earlier. 

This fix correctly exposes the react-switch props (as an intersection type, not a union type). This enables Typescript users to use one of the React.ComponentProps<> conditional types to infer all props of react-switch. 