### PR TITLE
Now the Github repo can directly be referenced from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "demo:prod": "webpack --mode production",
     "format": "prettier --write '**/*.{js,jsx,json}'",
     "lint": "eslint --ext .js,.jsx src/ demo/src",
+    "prepare": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "gzip-size": "node -e \"process.stdout.write('gzip size: ')\" && gzip-size --raw dist/react-switch.min.js",


### PR DESCRIPTION
In order to directly use a fork with experimental code from Github (without the need of deploying it to npm), package.json needs to contain a "prepare" script which basically performs the build. This way, the project can be included as a dependency in package.json like so:
```
    "react-switch": "git+https://github.com/username/react-switch.git",
```
