### PR TITLE
Add support for hex colors with alpha values

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ If you don't want to nest the switch inside a label, you can use the `htmlFor` a
 
 **NOTE**: All additional props will be passed to the nested `input` element.
 
-The following props have to be either 3-digit or 6-digit hex-colors:
+The following props have to be either 3-digit, 6-digit or 8-digit hex-colors:
 **offColor, onColor, offHandleColor,** and **onHandleColor.** This is because this library calculates intermediate color values based on the hex-color strings.
 
-Examples of valid colors: '#abc', '#123456'
+Examples of valid colors: '#abc', '#123456', '#123456ff'
 
 Examples of **invalid** colors: 'red', 'rgb(0,0,0)'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,8 @@ export interface ReactSwitchProps {
   disabled?: boolean;
 
   /**
-   * The switch will take on this color when it is **not** checked. Only accepts 3 or 6 digit hex colors, e.g., #888, #45abcd.
+   * The switch will take on this color when it is **not** checked. Only accepts 3 or 6 digit hex 
+   * colors (e.g., #888, #45abcd) or 8 digit hex colors with opacity (e.g., #45abcdff).
    *
    * Defaults to #888.
    */

--- a/src/getBackgroundColor.js
+++ b/src/getBackgroundColor.js
@@ -14,7 +14,7 @@ function createBackgroundColor(
   }
 
   let newColor = "#";
-  for (let i = 1; i < 6; i += 2) {
+  for (let i = 1; i < 8; i += 2) {
     const offComponent = parseInt(offColor.substr(i, 2), 16);
     const onComponent = parseInt(onColor.substr(i, 2), 16);
     const weightedValue = Math.round(
@@ -30,14 +30,17 @@ function createBackgroundColor(
 }
 
 function convertShorthandColor(color) {
-  if (color.length === 7) {
+  if (color.length === 9) {
     return color;
+  }
+  if (color.length === 7) {
+    return color + 'FF';
   }
   let sixDigitColor = "#";
   for (let i = 1; i < 4; i += 1) {
     sixDigitColor += color[i] + color[i];
   }
-  return sixDigitColor;
+  return sixDigitColor + 'FF';
 }
 
 export default function getBackgroundColor(
@@ -47,13 +50,13 @@ export default function getBackgroundColor(
   offColor,
   onColor
 ) {
-  const sixDigitOffColor = convertShorthandColor(offColor);
-  const sixDigitOnColor = convertShorthandColor(onColor);
+  const eightDigitOffColor = convertShorthandColor(offColor);
+  const eightDigitOnColor = convertShorthandColor(onColor);
   return createBackgroundColor(
     pos,
     checkedPos,
     uncheckedPos,
-    sixDigitOffColor,
-    sixDigitOnColor
+    eightDigitOffColor,
+    eightDigitOnColor
   );
 }

--- a/src/hexColorPropType.js
+++ b/src/hexColorPropType.js
@@ -4,10 +4,10 @@ const hexColorPropType = (props, propName, componentName) => {
   if (
     typeof prop !== "string" ||
     prop[0] !== "#" ||
-    (prop.length !== 4 && prop.length !== 7)
+    (prop.length !== 4 && prop.length !== 7 && prop.length !== 9)
   ) {
     return new Error(
-      `Invalid prop '${propName}' supplied to '${componentName}'. '${propName}' has to be either a 3-digit or 6-digit hex-color string. Valid examples: '#abc', '#123456'`
+      `Invalid prop '${propName}' supplied to '${componentName}'. '${propName}' has to be either a 3-digit, 6-digit or 8-digit hex-color string. Valid examples: '#abc', '#123456', '#123456FF'`
     );
   }
   return null;


### PR DESCRIPTION
Allows colors to be specified in #rrggbbaa format as well as the currently-supported formats.