### PR TITLE
feat: adding esm build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 if (process.env.NODE_ENV === "production") {
-  module.exports = require("./dist/react-switch.min.js");
+  module.exports = require("./dist/index.prod.js");
 } else {
-  module.exports = require("./dist/react-switch.dev.js");
+  module.exports = require("./dist/index.dev.js");
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "main": "index.js",
   "scripts": {
     "dev": "concurrently \"npm run lib:watch\" \"npm run demo:dev\"",
-    "build": "npm run lib:prod && npm run lib:dev && npm run demo:prod",
+    "build": "npm run build:lib && npm run demo:prod",
+    "build:lib": "rollup -c",
     "prepare": "npm run build",
     "lib:watch": "rollup -c -w -o dist/react-switch.dev.js",
-    "lib:dev": "rollup -c -o dist/react-switch.dev.js",
-    "lib:prod": "cross-env NODE_ENV=production rollup -c -o dist/react-switch.min.js",
     "demo:dev": "webpack-dev-server --mode development",
     "demo:prod": "webpack --mode production",
     "format": "prettier --write '**/*.{js,jsx,json}'",
@@ -85,5 +84,18 @@
   ],
   "dependencies": {
     "prop-types": "^15.7.2"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "import": "./dist/index.dev.mjs",
+        "require": "./dist/index.dev.js"
+      },
+      "production": {
+        "import": "./dist/index.prod.mjs",
+        "require": "./dist/index.prod.js"
+      },
+      "default": "./index.js"
+    }
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,48 +1,96 @@
 import babel from "rollup-plugin-babel";
 import buble from "rollup-plugin-buble";
 import { terser } from "rollup-plugin-terser";
+import path from "path";
 
-const config = {
-  input: "src/index.jsx",
-  output: {
-    format: "cjs",
-    interop: false,
-    strict: false,
-    exports: "named"
-  },
-  plugins: [
-    buble({ objectAssign: true }),
-    babel({
-      babelrc: false,
-      plugins: ["@babel/plugin-transform-object-assign"]
-    })
-  ],
-  external: ["react", "prop-types"]
-};
+// import { terser } from "rollup-plugin-terser";
 
-if (process.env.NODE_ENV === "production") {
-  config.plugins.push(
-    babel({
-      babelrc: false,
-      plugins: [
-        [
-          "transform-react-remove-prop-types",
-          {
-            removeImport: true,
-            additionalLibraries: ["./hexColorPropType"]
-          }
-        ]
+/**
+ * @type { [import('rollup').Plugin] }
+ */
+const prodPlugins = [
+  babel({
+    babelrc: false,
+    plugins: [
+      [
+        "transform-react-remove-prop-types",
+        {
+          removeImport: true,
+          additionalLibraries: ["./hexColorPropType"]
+        }
       ]
-    }),
-    terser({
-      mangle: {
-        properties: { regex: /^\$/ }
-      },
-      compress: {
-        pure_getters: true
-      }
-    })
-  );
-}
+    ]
+  }),
+  terser({
+    mangle: {
+      properties: { regex: /^\$/ }
+    },
+    compress: {
+      pure_getters: true
+    }
+  })
+]
 
-export default config;
+/**
+ * @type { [import('rollup').Plugin] }
+ */
+const commonPlugins = [
+  buble({ objectAssign: true }),
+  babel({
+    babelrc: false,
+    plugins: ["@babel/plugin-transform-object-assign"]
+  })
+];
+
+
+/**
+ * @type { [import('rollup').RollupOptions] }
+ */
+const configs = [
+  {
+    input: "src/index.jsx",
+    output: [
+      {
+        format: "cjs",
+        file: path.resolve(__dirname, "dist", "index.dev.js"),
+        interop: false,
+        strict: false,
+        exports: "named"
+      },
+      {
+        format: "esm",
+        file: path.resolve(__dirname, "dist", "index.dev.mjs"),
+        interop: false,
+        strict: false,
+        exports: "named"
+
+      }
+    ],
+    plugins: commonPlugins,
+    external: ["react", "prop-types"]
+  },
+  {
+    input: "src/index.jsx",
+    output: [
+      {
+        format: "cjs",
+        file: path.resolve(__dirname, "dist", "index.prod.js"),
+        interop: false,
+        strict: false,
+        exports: "named"
+      },
+      {
+        format: "esm",
+        file: path.resolve(__dirname, "dist", "index.prod.mjs"),
+        interop: false,
+        strict: false,
+        exports: "named"
+
+      }
+    ],
+    plugins: commonPlugins.concat(prodPlugins),
+    external: ["react", "prop-types"]
+  }
+]
+
+export default configs


### PR DESCRIPTION
closes: https://github.com/markusenglund/react-switch/issues/100

* simplified build process a little with type hints
* upgraded enzyme as it was giving me error message react not being version 16
* upgraded webpack as I wasn't able to install packages on node version 17.4.0 without upgrades

* added esm/cjs to package exports with conditional development/production

have tested this change in a vite project under dev and production and it seems to be working.

fyi: your typescript definitions are not currently defined in the package json
I didn't add it in this commit as I'm not sure how it should be handled for users since it depends on react types
